### PR TITLE
Use always copy mode at publishDir

### DIFF
--- a/modules/fastqc.nf
+++ b/modules/fastqc.nf
@@ -2,7 +2,7 @@ params.outdir = 'results'
 
 process FASTQC {
     tag "FASTQC on $sample_id"
-    publishDir params.outdir
+    publishDir params.outdir, mode:'copy'
 
     input:
     tuple val(sample_id), path(reads)


### PR DESCRIPTION
There are two modules that use `publishDir`:  `fastqc` and `multiqc`. Right now `multiqc` is using mode `copy` and `fastqc` no (so it's creating symbolic links). 

This PR is changing `fastqc` to also use `copy` mode to be consistent.

