### PR TITLE
ChangeModulePATH_andrmConda

### DIFF
--- a/modules/fastqc.nf
+++ b/modules/fastqc.nf
@@ -2,7 +2,6 @@ params.outdir = 'results'
 
 process FASTQC {
     tag "FASTQC on $sample_id"
-    conda 'bioconda::fastqc=0.11.9'
     publishDir params.outdir, mode:'copy'
 
     input:

--- a/modules/index.nf
+++ b/modules/index.nf
@@ -1,7 +1,6 @@
 
 process INDEX {
     tag "$transcriptome.simpleName"
-    conda 'bioconda::salmon=1.6.0'
     
     input:
     path transcriptome 

--- a/modules/multiqc.nf
+++ b/modules/multiqc.nf
@@ -1,7 +1,6 @@
 params.outdir = 'results'
 
 process MULTIQC {
-    conda 'bioconda::multiqc=1.11'
     publishDir params.outdir, mode:'copy'
 
     input:

--- a/modules/quant.nf
+++ b/modules/quant.nf
@@ -1,7 +1,6 @@
 
 process QUANT {
     tag "$pair_id"
-    conda 'bioconda::salmon=1.6.0'
 
     input:
     path index 


### PR DESCRIPTION
OK, It was actually just everything that was done in the last PR that messed up the run. So you could revert back to https://github.com/nextflow-io/rnaseq-nf/commit/d5554945251185326451a60cc11bbc97953315dd

Can we just keep the conda part in the config?