### PR TITLE
Add conda to PATH

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,4 +8,5 @@ RUN \
       multiqc=1.15 \
    && micromamba clean -a -y
 
+ENV PATH /opt/conda/bin:$PATH
 USER root

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,5 +8,5 @@ RUN \
       multiqc=1.15 \
    && micromamba clean -a -y
 
-ENV PATH /opt/conda/bin:$PATH
+ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
 USER root


### PR DESCRIPTION
Miniconda docker image had this, Micromamba does not. Required for usage with Singularity.