### PR TITLE
Annotation API

### DIFF
--- a/lib/Sample.groovy
+++ b/lib/Sample.groovy
@@ -1,0 +1,14 @@
+
+import java.nio.file.Path
+import nextflow.io.ValueObject
+import nextflow.util.KryoHelper
+
+@ValueObject
+class Sample {
+  String id
+  List<Path> reads
+
+  static {
+    KryoHelper.register(Sample)
+  }
+}

--- a/main.nf
+++ b/main.nf
@@ -50,7 +50,8 @@ include { MULTIQC } from './modules/multiqc'
 /* 
  * main script flow
  */
-workflow {
+@WorkflowFn(main=true)
+def MAIN() {
   read_pairs_ch = channel.fromFilePairs( params.reads, checkIfExists: true ).map { args -> new Sample(*args) }
   RNASEQ( file(params.transcriptome), read_pairs_ch )
   MULTIQC( RNASEQ.out, file(params.multiqc) )

--- a/main.nf
+++ b/main.nf
@@ -51,9 +51,9 @@ include { MULTIQC } from './modules/multiqc'
  * main script flow
  */
 workflow {
-  read_pairs_ch = channel.fromFilePairs( params.reads, checkIfExists: true ) 
-  RNASEQ( params.transcriptome, read_pairs_ch )
-  MULTIQC( RNASEQ.out, params.multiqc )
+  read_pairs_ch = channel.fromFilePairs( params.reads, checkIfExists: true ).map { args -> new Sample(*args) }
+  RNASEQ( file(params.transcriptome), read_pairs_ch )
+  MULTIQC( RNASEQ.out, file(params.multiqc) )
 }
 
 /* 

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -1,18 +1,21 @@
 params.outdir = 'results'
 
-process FASTQC {
-    tag "FASTQC on $sample_id"
-    conda 'fastqc=0.12.1'
-    publishDir params.outdir, mode:'copy'
-
-    input:
-    tuple val(sample_id), path(reads)
-
-    output:
-    path "fastqc_${sample_id}_logs" 
-
-    script:
+@ProcessFn(
+    directives={
+        tag { "FASTQC on $sample.id" }
+        conda 'fastqc=0.12.1'
+        publishDir params.outdir, mode:'copy'
+    },
+    inputs={
+        path { sample.reads }
+    },
+    outputs={
+        path { "fastqc_${sample.id}_logs" }
+    },
+    script=true
+)
+def FASTQC(Sample sample) {
     """
-    fastqc.sh "$sample_id" "$reads"
+    fastqc.sh "$sample.id" "${sample.reads.join(' ')}"
     """
 }

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -10,12 +10,13 @@ params.outdir = 'results'
         path { sample.reads }
     },
     outputs={
-        path { "fastqc_${sample.id}_logs" }
+        path '$file0', { "fastqc_${sample.id}_logs" }
+        emit { path('$file0') }
     },
     script=true
 )
 def FASTQC(Sample sample) {
     """
-    fastqc.sh "$sample.id" "${sample.reads.join(' ')}"
+    fastqc.sh "$sample.id" "$sample.reads"
     """
 }

--- a/modules/index/main.nf
+++ b/modules/index/main.nf
@@ -5,10 +5,11 @@
         conda 'salmon=1.10.2'
     },
     inputs={
-        path { transcriptome } 
+        path { transcriptome }
     },
     outputs={
-        path 'index' 
+        path '$file0', 'index'
+        emit { path('$file0') }
     },
     script=true
 )

--- a/modules/index/main.nf
+++ b/modules/index/main.nf
@@ -1,15 +1,18 @@
 
-process INDEX {
-    tag "$transcriptome.simpleName"
-    conda 'salmon=1.10.2'
-    
-    input:
-    path transcriptome 
-
-    output:
-    path 'index' 
-
-    script:
+@ProcessFn(
+    directives={
+        tag { transcriptome.simpleName }
+        conda 'salmon=1.10.2'
+    },
+    inputs={
+        path { transcriptome } 
+    },
+    outputs={
+        path 'index' 
+    },
+    script=true
+)
+def INDEX(Path transcriptome) {
     """
     salmon index --threads $task.cpus -t $transcriptome -i index
     """

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -10,7 +10,8 @@ params.outdir = 'results'
         path { config }
     },
     outputs={
-        path('multiqc_report.html')
+        path '$file0', 'multiqc_report.html'
+        emit { path('$file0') }
     },
     script=true
 )

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -1,17 +1,20 @@
 params.outdir = 'results'
 
-process MULTIQC {
-    conda 'multiqc=1.17'
-    publishDir params.outdir, mode:'copy'
-
-    input:
-    path('*') 
-    path(config) 
-
-    output:
-    path('multiqc_report.html')
-
-    script:
+@ProcessFn(
+    directives={
+        conda 'multiqc=1.17'
+        publishDir params.outdir, mode:'copy'
+    },
+    inputs={
+        path { files }, stageAs: '*'
+        path { config }
+    },
+    outputs={
+        path('multiqc_report.html')
+    },
+    script=true
+)
+def MULTIQC(List<Path> files, Path config) {
     """
     cp $config/* .
     echo "custom_logo: \$PWD/logo.png" >> multiqc_config.yaml

--- a/modules/quant/main.nf
+++ b/modules/quant/main.nf
@@ -9,7 +9,8 @@
         path { pair.reads }
     },
     outputs={
-        path { pair.id }
+        path '$file0', { pair.id }
+        emit { path('$file0') }
     },
     script=true
 )

--- a/modules/quant/main.nf
+++ b/modules/quant/main.nf
@@ -1,17 +1,20 @@
 
-process QUANT {
-    tag "$pair_id"
-    conda 'salmon=1.10.2'
-
-    input:
-    path index 
-    tuple val(pair_id), path(reads) 
-
-    output:
-    path pair_id 
-
-    script:
+@ProcessFn(
+    directives={
+        tag { pair.id }
+        conda 'salmon=1.10.2'
+    },
+    inputs={
+        path { index }
+        path { pair.reads }
+    },
+    outputs={
+        path { pair.id }
+    },
+    script=true
+)
+def QUANT(Path index, Sample pair) {
     """
-    salmon quant --threads $task.cpus --libType=U -i $index -1 ${reads[0]} -2 ${reads[1]} -o $pair_id
+    salmon quant --threads $task.cpus --libType=U -i $index -1 ${pair.reads[0]} -2 ${pair.reads[1]} -o $pair.id
     """
 }

--- a/modules/rnaseq.nf
+++ b/modules/rnaseq.nf
@@ -4,16 +4,11 @@ include { INDEX } from './index'
 include { QUANT } from './quant'
 include { FASTQC } from './fastqc'
 
-workflow RNASEQ {
-  take:
-    transcriptome
-    read_pairs_ch
- 
-  main: 
-    INDEX(transcriptome)
-    FASTQC(read_pairs_ch)
-    QUANT(INDEX.out, read_pairs_ch)
-
-  emit: 
-     QUANT.out | concat(FASTQC.out) | collect
+@WorkflowFn
+def RNASEQ(transcriptome, read_pairs_ch) {
+  INDEX(transcriptome)
+  FASTQC(read_pairs_ch)
+  QUANT(INDEX.out, read_pairs_ch)
+    | concat(FASTQC.out)
+    | collect
 }


### PR DESCRIPTION
This PR uses an experimental annotation API (Nextflow PR coming soon) to define processes.

Notable changes:
- processes are defined as regular functions with a `@ProcessFn` annotation that defines additional process configuration.
- the function parameters define the process inputs, while the `inputs` section in the annotation only defines how to stage files / environment vars / stdin based on the parameters
- similarly, the outputs section separates the staging out of files / envs / stdout from the outputs definition with `emit`
- the annotation uses the same builder DSL to define directives, inputs, and outputs
- the `script=true` denotes that the process generates script tasks, in which case the function should return the task script
- processes are invoked exactly as before, each input channel is mapped to a function argument
- since the process inputs can be statically typed, the sample tuple is replaced with a `Sample` class for better type checking