### PR TITLE
Add `-profile mamba`

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -9,25 +9,25 @@
  * defined by the Mozilla Public License, v. 2.0.
  *
  */
- 
+
 manifest {
-  description = 'Proof of concept of a RNA-seq pipeline implemented with Nextflow' 
+  description = 'Proof of concept of a RNA-seq pipeline implemented with Nextflow'
   author = 'Paolo Di Tommaso'
   nextflowVersion = '>=23.10.0'
 }
 
-/* 
- * default params 
+/*
+ * default params
  */
- 
+
 params.outdir = "results"
 params.reads = "${projectDir}/data/ggal/ggal_gut_{1,2}.fq"
 params.transcriptome = "${projectDir}/data/ggal/ggal_1_48850000_49020000.Ggal71.500bpflank.fa"
 params.multiqc = "${projectDir}/multiqc"
 
-/* 
- * defines execution profiles for different environments  
- */ 
+/*
+ * defines execution profiles for different environments
+ */
 
 profiles {
   standard {
@@ -66,15 +66,21 @@ profiles {
 
   'conda' {
     conda.enabled = true
-    conda.channels = 'seqera,conda-forge,bioconda,defaults'
+    conda.channels = 'conda-forge,bioconda,defaults'
   }
-  
+
+  'mamba' {
+    conda.enabled = true
+    conda.useMicromamba = true
+    conda.channels = 'conda-forge,bioconda,defaults'
+  }
+
   'slurm' {
     process.container = 'docker.io/nextflow/rnaseq-nf:v1.3.0'
     process.executor = 'slurm'
     singularity.enabled = true
   }
-  
+
   'batch' {
     params.reads = 's3://rnaseq-nf/data/ggal/lung_{1,2}.fq'
     params.transcriptome = 's3://rnaseq-nf/data/ggal/transcript.fa'
@@ -90,7 +96,7 @@ profiles {
     process.container = 'docker.io/nextflow/rnaseq-nf:v1.3.0'
     params.reads = 's3://rnaseq-nf/data/ggal/lung_{1,2}.fq'
     params.transcriptome = 's3://rnaseq-nf/data/ggal/transcript.fa'
-  } 
+  }
 
   'google-batch' {
       params.transcriptome = 'gs://rnaseq-nf/data/ggal/transcript.fa'
@@ -117,7 +123,7 @@ profiles {
     azure {
       batch {
         location = 'westeurope'
-        accountName = "$AZURE_BATCH_ACCOUNT_NAME" 
+        accountName = "$AZURE_BATCH_ACCOUNT_NAME"
         accountKey = "$AZURE_BATCH_ACCOUNT_KEY"
         autoPoolMode = true
         deletePoolsOnCompletion = true


### PR DESCRIPTION
Add a profile for mamba that corresponds to the conda one.

Also, remove `seqera` from conda channels. I don't think that this is needed any more, and its precedence ahead of `conda-forge` was breaking FastQC installation.

If `seqera` is needed, fine to add it back but it should be after `conda-forge`.