### PR TITLE
Workflow outputs (second preview)

### DIFF
--- a/bin/fastqc.sh
+++ b/bin/fastqc.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-sample_id="$1"
-reads="$2"
+reads="$1"
 
-mkdir fastqc_${sample_id}_logs
-fastqc -o fastqc_${sample_id}_logs -f fastq -q ${reads}
+mkdir fastqc
+fastqc -o fastqc -f fastq -q ${reads}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,9 @@ RUN \
       salmon=1.10.2 \
       fastqc=0.12.1 \
       multiqc=1.17 \
+      python=3.11 \
+      typing_extensions \
+      importlib_metadata \
       procps-ng \
    && micromamba clean -a -y
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN \
    micromamba install -y -n base -c defaults -c bioconda -c conda-forge \
       salmon=1.10.2 \
       fastqc=0.12.1 \
-      multiqc=1.15 \
+      multiqc=1.17 \
       procps-ng \
    && micromamba clean -a -y
 

--- a/main.nf
+++ b/main.nf
@@ -73,7 +73,7 @@ workflow {
 
 output {
   samples {
-    path '.'
+    path { id, _quant, _fastqc -> "${workflow.outputDir}/${id}" }
     index {
       path 'index.json'
       mapper { id, quant, fastqc ->

--- a/main.nf
+++ b/main.nf
@@ -61,4 +61,9 @@ workflow {
 output {
   directory params.outdir
   mode 'copy'
+  fastqc {
+    index {
+      path 'index.csv'
+    }
+  }
 }

--- a/main.nf
+++ b/main.nf
@@ -24,6 +24,7 @@
  * enables modules 
  */
 nextflow.enable.dsl = 2
+nextflow.preview.publish = true
 
 /*
  * Default pipeline parameters. They can be overriden on the command line eg.
@@ -63,15 +64,8 @@ workflow.onComplete {
 	log.info ( workflow.success ? "\nDone! Open the following report in your browser --> $params.outdir/multiqc_report.html\n" : "Oops .. something went wrong" )
 }
 
-output {
+publish {
   directory params.outdir
   mode 'copy'
 
-  'fastqc' {
-    path '.'
-  }
-
-  'multiqc' {
-    path '.'
-  }
 }

--- a/main.nf
+++ b/main.nf
@@ -56,9 +56,6 @@ workflow {
   read_pairs_ch = channel.fromFilePairs( params.reads, checkIfExists: true ) 
   RNASEQ( params.transcriptome, read_pairs_ch )
   MULTIQC( RNASEQ.out, params.multiqc )
-
-  publish:
-  MULTIQC.out >> '.'
 }
 
 output {

--- a/main.nf
+++ b/main.nf
@@ -62,3 +62,16 @@ workflow {
 workflow.onComplete {
 	log.info ( workflow.success ? "\nDone! Open the following report in your browser --> $params.outdir/multiqc_report.html\n" : "Oops .. something went wrong" )
 }
+
+output {
+  directory params.outdir
+  mode 'copy'
+
+  'fastqc' {
+    path '.'
+  }
+
+  'multiqc' {
+    path '.'
+  }
+}

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -1,19 +1,16 @@
 
 process FASTQC {
-    tag "FASTQC on $sample_id"
+    tag "$sample_id"
     conda 'fastqc=0.12.1'
 
     input:
-    tuple val(sample_id), path(reads)
+    tuple val(sample_id), path(fastq_1), path(fastq_2)
 
     output:
-    path "fastqc_${sample_id}_logs", emit: logs
-
-    publish:
-    logs >> 'fastqc'
+    tuple val(sample_id), path("fastqc_${sample_id}_logs"), emit: logs
 
     script:
     """
-    fastqc.sh "$sample_id" "$reads"
+    fastqc.sh "$sample_id" "$fastq_1 $fastq_2"
     """
 }

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -1,15 +1,16 @@
-params.outdir = 'results'
 
 process FASTQC {
     tag "FASTQC on $sample_id"
     conda 'fastqc=0.12.1'
-    publishDir params.outdir, mode:'copy'
 
     input:
     tuple val(sample_id), path(reads)
 
     output:
-    path "fastqc_${sample_id}_logs" 
+    path "fastqc_${sample_id}_logs", emit: logs
+
+    publish:
+    logs >> 'fastqc'
 
     script:
     """

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -7,10 +7,10 @@ process FASTQC {
     tuple val(sample_id), path(fastq_1), path(fastq_2)
 
     output:
-    tuple val(sample_id), path("fastqc_${sample_id}_logs"), emit: logs
+    tuple val(sample_id), path('fastqc')
 
     script:
     """
-    fastqc.sh "$sample_id" "$fastq_1 $fastq_2"
+    fastqc.sh "$fastq_1 $fastq_2"
     """
 }

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -9,9 +9,6 @@ process MULTIQC {
     output:
     path('multiqc_report.html'), emit: report
 
-    publish:
-    report >> 'multiqc'
-
     script:
     """
     cp $config/* .

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -1,15 +1,16 @@
-params.outdir = 'results'
 
 process MULTIQC {
     conda 'multiqc=1.17'
-    publishDir params.outdir, mode:'copy'
 
     input:
     path('*') 
     path(config) 
 
     output:
-    path('multiqc_report.html')
+    path('multiqc_report.html'), emit: report
+
+    publish:
+    report >> 'multiqc'
 
     script:
     """

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -1,7 +1,7 @@
 params.outdir = 'results'
 
 process MULTIQC {
-    conda 'multiqc=1.15'
+    conda 'multiqc=1.17'
     publishDir params.outdir, mode:'copy'
 
     input:

--- a/modules/quant/main.nf
+++ b/modules/quant/main.nf
@@ -1,17 +1,17 @@
 
 process QUANT {
-    tag "$pair_id"
+    tag "$sample_id"
     conda 'salmon=1.10.2'
 
     input:
-    path index 
-    tuple val(pair_id), path(reads) 
+    path index
+    tuple val(sample_id), path(fastq_1), path(fastq_2)
 
     output:
-    path pair_id 
+    tuple val(sample_id), path(sample_id)
 
     script:
     """
-    salmon quant --threads $task.cpus --libType=U -i $index -1 ${reads[0]} -2 ${reads[1]} -o $pair_id
+    salmon quant --threads $task.cpus --libType=U -i $index -1 ${fastq_1} -2 ${fastq_2} -o $sample_id
     """
 }

--- a/modules/quant/main.nf
+++ b/modules/quant/main.nf
@@ -8,10 +8,10 @@ process QUANT {
     tuple val(sample_id), path(fastq_1), path(fastq_2)
 
     output:
-    tuple val(sample_id), path(sample_id)
+    tuple val(sample_id), path('quant')
 
     script:
     """
-    salmon quant --threads $task.cpus --libType=U -i $index -1 ${fastq_1} -2 ${fastq_2} -o $sample_id
+    salmon quant --threads $task.cpus --libType=U -i $index -1 ${fastq_1} -2 ${fastq_2} -o quant
     """
 }

--- a/modules/rnaseq.nf
+++ b/modules/rnaseq.nf
@@ -8,12 +8,13 @@ workflow RNASEQ {
   take:
     transcriptome
     read_pairs_ch
- 
-  main: 
+
+  main:
     INDEX(transcriptome)
     FASTQC(read_pairs_ch)
     QUANT(INDEX.out, read_pairs_ch)
 
-  emit: 
-     QUANT.out | concat(FASTQC.out) | collect
+  emit:
+    quant = QUANT.out
+    fastqc = FASTQC.out
 }

--- a/modules/rnaseq.nf
+++ b/modules/rnaseq.nf
@@ -16,7 +16,4 @@ workflow RNASEQ {
 
   emit: 
      QUANT.out | concat(FASTQC.out) | collect
-
-  publish:
-    FASTQC.out >> '.'
 }


### PR DESCRIPTION
Second iteration based on #27 

This PR takes a different approach to workflow outputs by defining a `samples` target instead of having a target for each tool. The difference is harder to see here since we only publish the fastqc logs for each sample, but it is more clear for nf-core pipelines like fetchngs and rnaseq.

I originally treated each tool as an output target, but then I realized that it makes more sense to have a single output target that joins all results pertaining to a sample. This makes it much easier for a downstream pipeline to consume the outputs, because now instead of joining multiple index files, a downstream pipeline need only take a subset from the one index file.

It also publishes the salmon output, which is not essential, but demonstrates the idea of a "sample" being all results associated with a particular sample id.

The `multiqc` target could also be called `summary`, to denote that it contains the all of the summary results.