### PR TITLE
Repalce channel.fromFilePairs() with samplesheet

### DIFF
--- a/data/allreads.csv
+++ b/data/allreads.csv
@@ -1,0 +1,4 @@
+gut,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_2.fq
+liver,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_liver_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_liver_2.fq
+lung,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_lung_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_lung_2.fq
+spleen,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_spleen_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_spleen_2.fq

--- a/data/gut.csv
+++ b/data/gut.csv
@@ -1,0 +1,1 @@
+gut,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_2.fq

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -1,18 +1,18 @@
 params.outdir = 'results'
 
 process FASTQC {
-    tag "FASTQC on $sample_id"
+    tag "$id"
     conda 'bioconda::fastqc=0.12.1'
     publishDir params.outdir, mode:'copy'
 
     input:
-    tuple val(sample_id), path(reads)
+    tuple val(id), path(fastq_1), path(fastq_2)
 
     output:
-    path "fastqc_${sample_id}_logs", emit: logs
+    path "fastqc_${id}_logs", emit: logs
 
     script:
     """
-    fastqc.sh "$sample_id" "$reads"
+    fastqc.sh "$id" "$fastq_1" "$fastq_2"
     """
 }

--- a/modules/quant/main.nf
+++ b/modules/quant/main.nf
@@ -1,17 +1,17 @@
 
 process QUANT {
-    tag "$pair_id"
+    tag "$id"
     conda 'bioconda::salmon=1.10.3'
 
     input:
     path index 
-    tuple val(pair_id), path(reads) 
+    tuple val(id), path(fastq_1), path(fastq_2)
 
     output:
-    path pair_id 
+    path id 
 
     script:
     """
-    salmon quant --threads $task.cpus --libType=U -i $index -1 ${reads[0]} -2 ${reads[1]} -o $pair_id
+    salmon quant --threads $task.cpus --libType=U -i $index -1 ${fastq_1} -2 ${fastq_2} -o $id
     """
 }

--- a/modules/rnaseq.nf
+++ b/modules/rnaseq.nf
@@ -6,14 +6,14 @@ include { FASTQC } from './fastqc'
 
 workflow RNASEQ {
   take:
-    transcriptome
-    read_pairs_ch
+  transcriptome
+  samples_ch
  
   main: 
-    INDEX(transcriptome)
-    FASTQC(read_pairs_ch)
-    QUANT(INDEX.out, read_pairs_ch)
+  INDEX(transcriptome)
+  FASTQC(samples_ch)
+  QUANT(INDEX.out, samples_ch)
 
   emit: 
-     QUANT.out | concat(FASTQC.out) | collect
+  QUANT.out | concat(FASTQC.out) | collect
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,16 +17,14 @@ manifest {
 }
 
 /*
- * default params
+ * params for default test data
  */
 
-params.outdir = "results"
-params.reads = "${projectDir}/data/ggal/ggal_gut_{1,2}.fq"
-params.transcriptome = "${projectDir}/data/ggal/ggal_1_48850000_49020000.Ggal71.500bpflank.fa"
-params.multiqc = "${projectDir}/multiqc"
+params.reads = "${projectDir}/data/gut.csv"
+params.transcriptome = "https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_1_48850000_49020000.Ggal71.500bpflank.fa"
 
 /*
- * defines execution profiles for different environments
+ * execution profiles for different environments
  */
 
 profiles {
@@ -35,7 +33,7 @@ profiles {
   }
 
   'all-reads' {
-    params.reads = "${projectDir}/data/ggal/ggal_*_{1,2}.fq"
+    params.reads = "${projectDir}/data/allreads.csv"
   }
 
   'wave' {
@@ -82,8 +80,6 @@ profiles {
   }
 
   'batch' {
-    params.reads = 's3://rnaseq-nf/data/ggal/lung_{1,2}.fq'
-    params.transcriptome = 's3://rnaseq-nf/data/ggal/transcript.fa'
     process.container = 'docker.io/nextflow/rnaseq-nf:v1.3.0'
     process.executor = 'awsbatch'
     process.queue = 'nextflow-ci'
@@ -92,26 +88,12 @@ profiles {
     aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
   }
 
-  's3-data' {
-    process.container = 'docker.io/nextflow/rnaseq-nf:v1.3.0'
-    params.reads = 's3://rnaseq-nf/data/ggal/lung_{1,2}.fq'
-    params.transcriptome = 's3://rnaseq-nf/data/ggal/transcript.fa'
-  }
-
   'google-batch' {
-      params.transcriptome = 'gs://rnaseq-nf/data/ggal/transcript.fa'
-      params.reads = 'gs://rnaseq-nf/data/ggal/gut_{1,2}.fq'
       params.multiqc = 'gs://rnaseq-nf/multiqc'
       process.executor = 'google-batch'
       process.container = 'docker.io/nextflow/rnaseq-nf:v1.3.0'
       workDir = 'gs://rnaseq-nf/scratch' // <- replace with your own bucket!
       google.region  = 'europe-west2'
-  }
-
-  'gs-data' {
-      process.container = 'docker.io/nextflow/rnaseq-nf:v1.3.0'
-      params.transcriptome = 'gs://rnaseq-nf/data/ggal/transcript.fa'
-      params.reads = 'gs://rnaseq-nf/data/ggal/gut_{1,2}.fq'
   }
 
   'azure-batch' {


### PR DESCRIPTION
This PR replaces the use of `channel.fromFilePairs()` with a samplesheet.

The `fromFilePairs` factory should not be encouraged because it requires knowing how files are organized in a directory tree, and it isn't flexible enough to support arbitrary metadata.

This work aligns with #31 to model more clearly the inputs and outputs of a pipeline. Notably, the input is a samplesheet and the output is another samplesheet. These two PRs lay the groundwork for static types and pipeline chaining.

I have tried to keep the code as simple as possible while demonstrating best practices for workflow inputs.