### PR TITLE
Remove redundant azure config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -123,15 +123,8 @@ profiles {
     azure {
       batch {
         location = 'westeurope'
-        accountName = "$AZURE_BATCH_ACCOUNT_NAME"
-        accountKey = "$AZURE_BATCH_ACCOUNT_KEY"
         autoPoolMode = true
         deletePoolsOnCompletion = true
-      }
-
-      storage {
-        accountName = "$AZURE_STORAGE_ACCOUNT_NAME"
-        accountKey = "$AZURE_STORAGE_ACCOUNT_KEY"
       }
     }
   }


### PR DESCRIPTION
I think these settings can be removed because Nextflow will fall back to these environment variables anyway. The strict syntax also complains about them since implicit environment vars aren't allowed anymore