### PR TITLE
Preview: Nextflow 26.04

### DIFF
--- a/data/allreads.csv
+++ b/data/allreads.csv
@@ -1,0 +1,4 @@
+gut,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_2.fq
+liver,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_liver_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_liver_2.fq
+lung,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_lung_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_lung_2.fq
+spleen,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_spleen_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_spleen_2.fq

--- a/data/gut.csv
+++ b/data/gut.csv
@@ -1,0 +1,1 @@
+gut,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_2.fq

--- a/main.nf
+++ b/main.nf
@@ -7,13 +7,12 @@
 
 /*
  * Default pipeline parameters. They can be overriden on the command line eg.
- * given `params.foo` specify on the run command line `--foo some_value`.
+ * given `params.reads` specify on the run command line `--reads some_value`.
  */
 
-params.reads = "${baseDir}/data/ggal/ggal_gut_{1,2}.fq"
-params.transcriptome = "${baseDir}/data/ggal/ggal_1_48850000_49020000.Ggal71.500bpflank.fa"
-params.outdir = "results"
-params.multiqc = "${baseDir}/multiqc"
+params.reads = null
+params.transcriptome = null
+params.multiqc = "${projectDir}/multiqc"
 
 
 // import modules
@@ -24,28 +23,57 @@ include { MULTIQC } from './modules/multiqc'
  * main script flow
  */
 workflow {
-
+    main:
     log.info """\
       R N A S E Q - N F   P I P E L I N E
       ===================================
       transcriptome: ${params.transcriptome}
       reads        : ${params.reads}
-      outdir       : ${params.outdir}
+      outdir       : ${workflow.outputDir}
     """.stripIndent()
 
-    read_pairs_ch = channel.fromFilePairs(params.reads, checkIfExists: true, flat: true)
+    read_pairs_ch = channel.fromPath(params.reads)
+        .flatMap { csv -> csv.splitCsv() }
+        .map { id, fastq_1, fastq_2 ->
+            tuple(id, file(fastq_1, checkIfExists: true), file(fastq_2, checkIfExists: true))
+        }
 
-    (fastqc_ch, quant_ch) = RNASEQ(read_pairs_ch, params.transcriptome)
+    samples_ch = RNASEQ(read_pairs_ch, params.transcriptome)
 
-    multiqc_files_ch = fastqc_ch.mix(quant_ch).collect()
+    multiqc_files_ch = samples_ch
+        .flatMap { id, fastqc, quant -> [fastqc, quant] }
+        .collect()
 
-    MULTIQC(multiqc_files_ch, params.multiqc)
+    multiqc_report = MULTIQC(multiqc_files_ch, params.multiqc)
 
     workflow.onComplete = {
         log.info(
             workflow.success
-                ? "\nDone! Open the following report in your browser --> ${params.outdir}/multiqc_report.html\n"
+                ? "\nDone! Open the following report in your browser --> ${workflow.outputDir}/multiqc_report.html\n"
                 : "Oops .. something went wrong"
         )
+    }
+
+    publish:
+    samples = samples_ch.map { id, fastqc, quant -> [id: id, fastqc: fastqc, quant: quant] }
+    multiqc_report = multiqc_report
+}
+
+/* 
+ * workflow outputs
+ */
+output {
+    samples {
+        path { sample ->
+            sample.fastqc >> "fastqc/${sample.id}"
+            sample.quant >> "quant/${sample.id}"
+        }
+        index {
+            path 'samples.csv'
+            header true
+        }
+    }
+
+    multiqc_report {
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -4,20 +4,30 @@
  * Proof of concept of a RNAseq pipeline implemented with Nextflow
  */
 
+nextflow.preview.types = true
 
 /*
  * Default pipeline parameters. They can be overriden on the command line eg.
  * given `params.reads` specify on the run command line `--reads some_value`.
  */
 
-params.reads = null
-params.transcriptome = null
-params.multiqc = "${projectDir}/multiqc"
+params {
+    // The input read-pair files
+    reads: Path
+
+    // The input transcriptome file
+    transcriptome: Path
+
+    // Directory containing multiqc configuration
+    multiqc: Path = "${projectDir}/multiqc"
+}
 
 
 // import modules
 include { RNASEQ } from './modules/rnaseq'
 include { MULTIQC } from './modules/multiqc'
+
+include { AlignedSample } from './modules/rnaseq'
 
 /* 
  * main script flow
@@ -32,30 +42,23 @@ workflow {
       outdir       : ${workflow.outputDir}
     """.stripIndent()
 
-    read_pairs_ch = channel.fromPath(params.reads)
+    read_pairs_ch = channel.of(params.reads)
         .flatMap { csv -> csv.splitCsv() }
-        .map { id, fastq_1, fastq_2 ->
-            tuple(id, file(fastq_1, checkIfExists: true), file(fastq_2, checkIfExists: true))
+        .map { row -> row as List<String> }
+        .map { row ->
+            record(id: row[0], fastq_1: file(row[1], checkIfExists: true), fastq_2: file(row[2], checkIfExists: true))
         }
 
     samples_ch = RNASEQ(read_pairs_ch, params.transcriptome)
 
     multiqc_files_ch = samples_ch
-        .flatMap { id, fastqc, quant -> [fastqc, quant] }
+        .flatMap { r -> [r.fastqc, r.quant] }
         .collect()
 
     multiqc_report = MULTIQC(multiqc_files_ch, params.multiqc)
 
-    workflow.onComplete = {
-        log.info(
-            workflow.success
-                ? "\nDone! Open the following report in your browser --> ${workflow.outputDir}/multiqc_report.html\n"
-                : "Oops .. something went wrong"
-        )
-    }
-
     publish:
-    samples = samples_ch.map { id, fastqc, quant -> [id: id, fastqc: fastqc, quant: quant] }
+    samples = samples_ch
     multiqc_report = multiqc_report
 }
 
@@ -63,7 +66,7 @@ workflow {
  * workflow outputs
  */
 output {
-    samples {
+    samples: Channel<AlignedSample> {
         path { sample ->
             sample.fastqc >> "fastqc/${sample.id}"
             sample.quant >> "quant/${sample.id}"
@@ -74,6 +77,6 @@ output {
         }
     }
 
-    multiqc_report {
+    multiqc_report: Path {
     }
 }

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -1,15 +1,13 @@
-params.outdir = 'results'
 
 process FASTQC {
     tag "${id}"
     conda 'bioconda::fastqc=0.12.1'
-    publishDir params.outdir, mode: 'copy'
 
     input:
     tuple val(id), path(fastq_1), path(fastq_2)
 
     output:
-    path "fastqc_${id}_logs"
+    tuple val(id), path("fastqc_${id}_logs")
 
     script:
     """

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -1,13 +1,22 @@
 
+nextflow.preview.types = true
+
 process FASTQC {
-    tag "${id}"
+    tag id
     conda 'bioconda::fastqc=0.12.1'
 
     input:
-    tuple val(id), path(fastq_1), path(fastq_2)
+    record(
+        id: String,
+        fastq_1: Path,
+        fastq_2: Path
+    )
 
     output:
-    tuple val(id), path("fastqc_${id}_logs")
+    record(
+        id: id,
+        fastqc: file("fastqc_${id}_logs")
+    )
 
     script:
     """

--- a/modules/index/main.nf
+++ b/modules/index/main.nf
@@ -1,13 +1,15 @@
 
+nextflow.preview.types = true
+
 process INDEX {
     tag "${transcriptome.simpleName}"
     conda 'bioconda::salmon=1.10.3'
 
     input:
-    path transcriptome
+    transcriptome: Path
 
     output:
-    path 'index'
+    file('index')
 
     script:
     """

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -1,8 +1,6 @@
-params.outdir = 'results'
 
 process MULTIQC {
     conda 'bioconda::multiqc=1.27.1'
-    publishDir params.outdir, mode: 'copy'
 
     input:
     path '*'

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -1,13 +1,15 @@
 
+nextflow.preview.types = true
+
 process MULTIQC {
     conda 'bioconda::multiqc=1.27.1'
 
     input:
-    path '*'
-    path config
+    logs: Bag<Path>
+    config: Path
 
     output:
-    path 'multiqc_report.html'
+    file('multiqc_report.html')
 
     script:
     """

--- a/modules/quant/main.nf
+++ b/modules/quant/main.nf
@@ -8,7 +8,7 @@ process QUANT {
     path index
 
     output:
-    path "quant_${id}"
+    tuple val(id), path("quant_${id}")
 
     script:
     """

--- a/modules/quant/main.nf
+++ b/modules/quant/main.nf
@@ -1,17 +1,32 @@
 
+nextflow.preview.types = true
+
 process QUANT {
-    tag "${id}"
+    tag id
     conda 'bioconda::salmon=1.10.3'
 
     input:
-    tuple val(id), path(fastq_1), path(fastq_2)
-    path index
+    record(
+        id: String,
+        fastq_1: Path,
+        fastq_2: Path
+    )
+    index: Path
 
     output:
-    tuple val(id), path("quant_${id}")
+    record(
+        id: id,
+        quant: file("quant_${id}")
+    )
 
     script:
     """
-    salmon quant --threads ${task.cpus} --libType=U -i ${index} -1 ${fastq_1} -2 ${fastq_2} -o quant_${id}
+    salmon quant \
+        --threads ${task.cpus} \
+        --libType=U \
+        -i ${index} \
+        -1 ${fastq_1} \
+        -2 ${fastq_2} \
+        -o quant_${id}
     """
 }

--- a/modules/rnaseq.nf
+++ b/modules/rnaseq.nf
@@ -11,8 +11,8 @@ workflow RNASEQ {
     index = INDEX(transcriptome)
     fastqc_ch = FASTQC(read_pairs_ch)
     quant_ch = QUANT(read_pairs_ch, index)
+    samples_ch = fastqc_ch.join(quant_ch)
 
     emit:
-    fastqc = fastqc_ch
-    quant = quant_ch
+    samples = samples_ch
 }

--- a/modules/rnaseq.nf
+++ b/modules/rnaseq.nf
@@ -1,18 +1,33 @@
+
+nextflow.preview.types = true
+
 include { INDEX } from './index'
 include { QUANT } from './quant'
 include { FASTQC } from './fastqc'
 
 workflow RNASEQ {
     take:
-    read_pairs_ch
-    transcriptome
+    read_pairs_ch: Channel<Sample>
+    transcriptome: Path
 
     main:
     index = INDEX(transcriptome)
     fastqc_ch = FASTQC(read_pairs_ch)
     quant_ch = QUANT(read_pairs_ch, index)
-    samples_ch = fastqc_ch.join(quant_ch)
+    samples_ch = fastqc_ch.join(quant_ch, by: 'id')
 
     emit:
-    samples = samples_ch
+    samples: Channel<AlignedSample> = samples_ch
+}
+
+record Sample {
+    id: String
+    fastq_1: Path
+    fastq_2: Path
+}
+
+record AlignedSample {
+    id: String
+    fastqc: Path
+    quant: Path
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,20 +13,24 @@
 manifest {
     description = 'Proof of concept of a RNA-seq pipeline implemented with Nextflow'
     author = 'Paolo Di Tommaso'
-    nextflowVersion = '>=23.10.0'
+    nextflowVersion = '>=25.10.0'
 }
 
 /*
- * default params
+ * params for default test data
  */
 
-params.outdir = "results"
-params.reads = "${projectDir}/data/ggal/ggal_gut_{1,2}.fq"
-params.transcriptome = "${projectDir}/data/ggal/ggal_1_48850000_49020000.Ggal71.500bpflank.fa"
-params.multiqc = "${projectDir}/multiqc"
+params.reads = "${projectDir}/data/gut.csv"
+params.transcriptome = "https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_1_48850000_49020000.Ggal71.500bpflank.fa"
 
 /*
- * defines execution profiles for different environments
+ * publish settings
+ */
+
+workflow.output.mode = 'copy'
+
+/*
+ * execution profiles for different environments
  */
 
 profiles {
@@ -35,7 +39,7 @@ profiles {
     }
 
     'all-reads' {
-        params.reads = "${projectDir}/data/ggal/ggal_*_{1,2}.fq"
+        params.reads = "${projectDir}/data/allreads.csv"
     }
 
     arm64 {
@@ -83,8 +87,6 @@ profiles {
     }
 
     batch {
-        params.reads = 's3://rnaseq-nf/data/ggal/lung_{1,2}.fq'
-        params.transcriptome = 's3://rnaseq-nf/data/ggal/transcript.fa'
         process.container = 'docker.io/nextflow/rnaseq-nf:v1.3.1'
         process.executor = 'awsbatch'
         process.queue = 'nextflow-ci'
@@ -93,15 +95,7 @@ profiles {
         aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
     }
 
-    's3-data' {
-        process.container = 'docker.io/nextflow/rnaseq-nf:v1.3.1'
-        params.reads = 's3://rnaseq-nf/data/ggal/lung_{1,2}.fq'
-        params.transcriptome = 's3://rnaseq-nf/data/ggal/transcript.fa'
-    }
-
     'google-batch' {
-        params.transcriptome = 'gs://rnaseq-nf/data/ggal/transcript.fa'
-        params.reads = 'gs://rnaseq-nf/data/ggal/gut_{1,2}.fq'
         params.multiqc = 'gs://rnaseq-nf/multiqc'
         process.executor = 'google-batch'
         process.container = 'docker.io/nextflow/rnaseq-nf:v1.3.1'
@@ -110,12 +104,6 @@ profiles {
          */
         workDir = 'gs://rnaseq-nf/scratch'
         google.region = 'europe-west2'
-    }
-
-    'gs-data' {
-        process.container = 'docker.io/nextflow/rnaseq-nf:v1.3.1'
-        params.transcriptome = 'gs://rnaseq-nf/data/ggal/transcript.fa'
-        params.reads = 'gs://rnaseq-nf/data/ggal/gut_{1,2}.fq'
     }
 
     'azure-batch' {


### PR DESCRIPTION
This PR provides a comprehensive preview of new language features.

I will keep the `preview` branch up to date with the latest language features so that we have a good public example for users to try. Simply run the pipeline and specify `preview` as the revision:

```bash
nextflow run rnaseq-nf -r preview [...]
```

(Note: until Nextflow 25.10 is released, this will require building Nextflow locally from the `master` branch)

This seems like a better alternative to updating `master`, which would break compatibility with older pipelines.

**Summary of changes**

[25.04](https://github.com/nextflow-io/rnaseq-nf/tree/preview-25-04)
- Workflow outputs (third preview)
- Replace `channel.fromFilePairs()` with samplesheet

[25.10](https://github.com/nextflow-io/rnaseq-nf/tree/preview-25-10)
- Workflow params
- Workflow `onComplete` section
- Type annotations

26.04 (this branch)
- Records and record types