### PR TITLE
Align with best practices

### DIFF
--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -6,13 +6,13 @@ process FASTQC {
     publishDir params.outdir, mode: 'copy'
 
     input:
-    tuple val(id), path(reads)
+    tuple val(id), path(fastq_1), path(fastq_2)
 
     output:
-    path "fastqc_${id}_logs", emit: logs
+    tuple val(id), path("fastqc_${id}_logs")
 
     script:
     """
-    fastqc.sh "${id}" "${reads}"
+    fastqc.sh "${id}" "${fastq_1} ${fastq_2}"
     """
 }

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -9,7 +9,7 @@ process MULTIQC {
     path config
 
     output:
-    path 'multiqc_report.html', emit: report
+    path 'multiqc_report.html'
 
     script:
     """

--- a/modules/quant/main.nf
+++ b/modules/quant/main.nf
@@ -4,14 +4,14 @@ process QUANT {
     conda 'bioconda::salmon=1.10.3'
 
     input:
+    tuple val(id), path(fastq_1), path(fastq_2)
     path index
-    tuple val(id), path(reads)
 
     output:
-    path id
+    tuple val(id), path("quant_${id}")
 
     script:
     """
-    salmon quant --threads ${task.cpus} --libType=U -i ${index} -1 ${reads[0]} -2 ${reads[1]} -o ${id}
+    salmon quant --threads ${task.cpus} --libType=U -i ${index} -1 ${fastq_1} -2 ${fastq_2} -o quant_${id}
     """
 }

--- a/modules/rnaseq.nf
+++ b/modules/rnaseq.nf
@@ -4,14 +4,16 @@ include { FASTQC } from './fastqc'
 
 workflow RNASEQ {
     take:
-    transcriptome
     read_pairs_ch
+    transcriptome
 
     main:
-    INDEX(transcriptome)
-    FASTQC(read_pairs_ch)
-    QUANT(INDEX.out, read_pairs_ch)
+    index = INDEX(transcriptome)
+    fastqc_ch = FASTQC(read_pairs_ch)
+    quant_ch = QUANT(read_pairs_ch, index)
+    samples_ch = fastqc_ch.join(quant_ch)
 
     emit:
-    QUANT.out | concat(FASTQC.out) | collect
+    samples = samples_ch
+    index = index
 }


### PR DESCRIPTION
This PR aligns the source code with the initial version in [Migrating to workflow outputs](https://nextflow.io/docs/latest/tutorials/workflow-outputs.html)

- replace `reads` with `fastq_1` and `fastq_2`
- include index and quant results in `RNASEQ` output

It aligns the pipeline code with best practices around structuring data while keeping it compatible with Nextflow 23.10. It will allow us to simplify the migration guides since we won't need to apply these changes in the tutorial