### PR TITLE
Align with migration tutorial

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -35,11 +35,9 @@ workflow {
 
     read_pairs_ch = channel.fromFilePairs(params.reads, checkIfExists: true, flat: true)
 
-    (samples_ch, index) = RNASEQ(read_pairs_ch, params.transcriptome)
+    (fastqc_ch, quant_ch) = RNASEQ(read_pairs_ch, params.transcriptome)
 
-    multiqc_files_ch = samples_ch
-        .flatMap { id, fastqc, quant -> [fastqc, quant] }
-        .collect()
+    multiqc_files_ch = fastqc_ch.mix(quant_ch).collect()
 
     MULTIQC(multiqc_files_ch, params.multiqc)
 

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -9,7 +9,7 @@ process FASTQC {
     tuple val(id), path(fastq_1), path(fastq_2)
 
     output:
-    tuple val(id), path("fastqc_${id}_logs")
+    path "fastqc_${id}_logs"
 
     script:
     """

--- a/modules/quant/main.nf
+++ b/modules/quant/main.nf
@@ -8,7 +8,7 @@ process QUANT {
     path index
 
     output:
-    tuple val(id), path("quant_${id}")
+    path "quant_${id}"
 
     script:
     """

--- a/modules/rnaseq.nf
+++ b/modules/rnaseq.nf
@@ -11,9 +11,8 @@ workflow RNASEQ {
     index = INDEX(transcriptome)
     fastqc_ch = FASTQC(read_pairs_ch)
     quant_ch = QUANT(read_pairs_ch, index)
-    samples_ch = fastqc_ch.join(quant_ch)
 
     emit:
-    samples = samples_ch
-    index = index
+    fastqc = fastqc_ch
+    quant = quant_ch
 }


### PR DESCRIPTION
This PR reverts some changes from the previous commit to make it more amenable to the "Migrating to workflow outputs" tutorial

It keeps the fastqc and quant results in separate channels, so that in the workflow outputs tutorial we can show how to join them into a single channel.