### PR TITLE
Update to Nextflow 25.10 and workflow outputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: ['21']
-        nextflow_version: ['23.10']
+        nextflow_version: ['25.10']
 
     steps:
       - name: Environment

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A basic pipeline for quantification of genomic features from short-read data, im
 ## Requirements
 
 * Unix-like operating system (Linux, macOS, etc)
-* Java 11
+* Java 17
 
 ## Quickstart
 
 1. Install [Docker](https://docs.docker.com/) if you don't have it already.
 
-2. Install Nextflow (version 23.10 or later):
+2. Install Nextflow (version 25.10 or later):
 
    ```bash
    curl -s https://get.nextflow.io | bash

--- a/main.nf
+++ b/main.nf
@@ -1,4 +1,4 @@
-#!/usr/bin/env nextflow 
+#!/usr/bin/env nextflow
 
 /*
  * Proof of concept of a RNAseq pipeline implemented with Nextflow
@@ -11,7 +11,6 @@
 
 params.reads = null
 params.transcriptome = null
-params.outdir = "results"
 params.multiqc = "${projectDir}/multiqc"
 
 
@@ -19,17 +18,17 @@ params.multiqc = "${projectDir}/multiqc"
 include { RNASEQ } from './modules/rnaseq'
 include { MULTIQC } from './modules/multiqc'
 
-/* 
+/*
  * main script flow
  */
 workflow {
-
+    main:
     log.info """\
       R N A S E Q - N F   P I P E L I N E
       ===================================
       transcriptome: ${params.transcriptome}
       reads        : ${params.reads}
-      outdir       : ${params.outdir}
+      outdir       : ${workflow.outputDir}
     """.stripIndent()
 
     // Create a channel of paired-end reads from the glob in `params.reads`.
@@ -39,25 +38,60 @@ workflow {
     read_pairs_ch = channel.fromFilePairs(params.reads, checkIfExists: true, flat: true)
 
     // Run the RNASEQ sub-workflow over each read pair against the transcriptome.
-    // It emits two channels which we destructure here:
-    //   - fastqc_ch: per-sample FastQC report directories
-    //   - quant_ch : per-sample Salmon quantification directories
-    (fastqc_ch, quant_ch) = RNASEQ(read_pairs_ch, params.transcriptome)
+    // It emits a channel of tuples with the following elements:
+    //   - per-sample ID
+    //   - per-sample FastQC report directories
+    //   - per-sample Salmon quantification directories
+    samples_ch = RNASEQ(read_pairs_ch, params.transcriptome)
 
-    // Mix FastQC and Salmon outputs into a single stream (`mix`) and collect
-    // every emission into a list (`collect`) so that MultiQC sees all results at
+    // Extract the FastQC and Salmon outputs into a single stream (`flatMap`) and
+    // collect them into a list (`collect`) so that MultiQC sees all results at
     // once, e.g. [fastqc/ggal_gut, quant/ggal_gut, fastqc/ggal_liver, ...].
-    multiqc_files_ch = fastqc_ch.mix(quant_ch).collect()
+    multiqc_files_ch = samples_ch
+        .flatMap { id, fastqc, quant -> [fastqc, quant] }
+        .collect()
 
     // Run MultiQC on the collected result files using the config in `params.multiqc`
     // to produce a single consolidated HTML report (`multiqc_report.html`).
-    MULTIQC(multiqc_files_ch, params.multiqc)
+    multiqc_report = MULTIQC(multiqc_files_ch, params.multiqc)
 
-    workflow.onComplete = {
-        log.info(
-            workflow.success
-                ? "\nDone! Open the following report in your browser --> ${params.outdir}/multiqc_report.html\n"
-                : "Oops .. something went wrong"
-        )
+    // Publish per-sample results and aggregated MultiQC report as workflow outputs
+    // The directory paths for these outputs are defined in the `output` block below.
+    publish:
+    samples = samples_ch.map { id, fastqc, quant -> [id: id, fastqc: fastqc, quant: quant] }
+    multiqc_report = multiqc_report
+}
+
+/*
+ * workflow outputs
+ *
+ * The `output` block defines the directory structure of published outputs.
+ * The base output directory can be set using the `-output-dir` CLI option
+ * or `outputDir` config option. It defaults to `results`.
+ * By default, all published files are saved directly in the output directory.
+ * The `path` directive can be used to route files to specific paths within
+ * the output directory.
+ */
+output {
+    // Publish the per-sample FastQC and Salmon results into
+    // the `fastqc` and `quant` subdirectories, respectively.
+    samples {
+        // Per-sample results are separated further into subdirectories
+        // by ID (e.g. `fastqc/ggal_gut`, `fastqc/ggal_liver`, etc).
+        path { sample ->
+            sample.fastqc >> "fastqc/${sample.id}"
+            sample.quant >> "quant/${sample.id}"
+        }
+        // Create an index file (samplesheet) of the published
+        // samples in the output directory, e.g. `results/samples.csv`.
+        index {
+            path 'samples.csv'
+            header true
+        }
+    }
+
+    // Publish the aggregated MultiQC HTML report in the
+    // output directory, e.g. `results/multiqc_report.html`
+    multiqc_report {
     }
 }

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -1,15 +1,13 @@
-params.outdir = 'results'
 
 process FASTQC {
     tag "${id}"
     conda 'bioconda::fastqc=0.12.1'
-    publishDir params.outdir, mode: 'copy'
 
     input:
     tuple val(id), path(fastq_1), path(fastq_2)
 
     output:
-    path "fastqc_${id}_logs"
+    tuple val(id), path("fastqc_${id}_logs")
 
     script:
     """

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -1,8 +1,6 @@
-params.outdir = 'results'
 
 process MULTIQC {
     conda 'bioconda::multiqc=1.27.1'
-    publishDir params.outdir, mode: 'copy'
 
     input:
     path '*'

--- a/modules/quant/main.nf
+++ b/modules/quant/main.nf
@@ -8,7 +8,7 @@ process QUANT {
     path index
 
     output:
-    path "quant_${id}"
+    tuple val(id), path("quant_${id}")
 
     script:
     """

--- a/modules/rnaseq.nf
+++ b/modules/rnaseq.nf
@@ -11,8 +11,8 @@ workflow RNASEQ {
     index = INDEX(transcriptome)
     fastqc_ch = FASTQC(read_pairs_ch)
     quant_ch = QUANT(read_pairs_ch, index)
+    samples_ch = fastqc_ch.join(quant_ch)
 
     emit:
-    fastqc = fastqc_ch
-    quant = quant_ch
+    samples = samples_ch
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,20 +2,25 @@
 manifest {
     description = 'Proof of concept of a RNA-seq pipeline implemented with Nextflow'
     author = 'Paolo Di Tommaso'
-    nextflowVersion = '>=23.10.0'
+    nextflowVersion = '>=25.10.0'
 }
 
 /*
- * default params
+ * params for default test data
  */
 
-params.outdir = "results"
 params.reads = "${projectDir}/data/ggal/ggal_gut_{1,2}.fq"
 params.transcriptome = "${projectDir}/data/ggal/ggal_1_48850000_49020000.Ggal71.500bpflank.fa"
 params.multiqc = "${projectDir}/multiqc"
 
 /*
- * defines execution profiles for different environments
+ * publish settings
+ */
+
+workflow.output.mode = 'copy'
+
+/*
+ * execution profiles for different environments
  */
 
 profiles {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -11,13 +11,6 @@
       "fa_icon": "fas fa-terminal",
       "description": "Define where the pipeline should find input data and save output data.",
       "properties": {
-        "outdir": {
-          "type": "string",
-          "format": "directory-path",
-          "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
-          "fa_icon": "fas fa-folder-open",
-          "default": "results"
-        },
         "reads": {
           "type": "string",
           "description": "The input read-pair files",


### PR DESCRIPTION
## Summary
- Bump required Nextflow version to `>=25.10.0` in the manifest, the README quickstart and the CI matrix; update the README Java requirement from 11 to 17.
- Modernize `main.nf` to use the new `publish:` / `output { }` syntax, drop the now-redundant `publishDir` from the FASTQC and MULTIQC modules, and add inline comments explaining the workflow body and the output block.
- Resolve the dual-license inconsistency: delete the stray MPL 2.0 `LICENSE.txt`, restore the missing `END OF TERMS AND CONDITIONS` / `APPENDIX` block (with the `Copyright 2013-2026 Seqera Labs` notice) in the Apache `LICENSE`, and drop the stale MPL header from `nextflow.config`.
- Add `lineage` to `.gitignore`.

## Test plan
- [ ] CI build passes on the new Nextflow 25.10 / Java 21 matrix
- [ ] `nextflow run . -profile docker` produces `results/fastqc_files/...` and `results/multiqc_report/multiqc_report.html` via the new `output { }` block
- [ ] Confirm only `LICENSE` (Apache 2.0) remains and the file ends with the APPENDIX copyright notice
- [ ] Confirm no source file still references the Mozilla Public License

🤖 Generated with [Claude Code](https://claude.com/claude-code)