### PR TITLE
Add dev container (Nextflow, nf-test, Docker-in-Docker, Seqera CLI)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
     },
     "remoteEnv": {
         "NXF_HOME": "/workspaces/.nextflow",
-        "NXF_VER": "25.10.4",
+        "NXF_VER": "26.04.4",
         "NXF_SYNTAX_PARSER": "v2"
     },
     "onCreateCommand": "bash .devcontainer/setup.sh",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// Dev container for rnaseq-nf
+// Provides Nextflow, nf-test, Docker-in-Docker and the Seqera CLI.
+// Inspired by the nextflow-io/training dev container setup.
+{
+    "name": "rnaseq-nf",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+    "features": {
+        // Java is required by Nextflow and nf-test (matches CI: Java 21 / temurin)
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "21",
+            "jdkDistro": "tem"
+        },
+        // Docker-in-Docker so the pipeline can pull and run process containers
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        // Node is needed for the Seqera CLI (npm install -g seqera)
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "lts"
+        }
+    },
+    "remoteEnv": {
+        "NXF_HOME": "/workspaces/.nextflow",
+        "NXF_VER": "25.10.4",
+        "NXF_SYNTAX_PARSER": "v2"
+    },
+    "onCreateCommand": "bash .devcontainer/setup.sh",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "nf-core.nf-core-extensionpack"
+            ],
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash"
+            }
+        }
+    }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -2,6 +2,13 @@
 # Provision Nextflow, nf-test and the Seqera CLI inside the dev container.
 set -euo pipefail
 
+# xdg-utils provides `xdg-open`, which the Seqera CLI uses to open the browser
+# during `seqera login`. Without it the CLI crashes instead of falling back to
+# the printed auth URL (the OAuth callback port is forwarded by VS Code).
+echo "Installing OS dependencies..."
+sudo apt-get update -qq
+sudo apt-get install -y -qq xdg-utils
+
 echo "Installing Nextflow (NXF_VER=${NXF_VER:-latest})..."
 curl -s https://get.nextflow.io | bash
 sudo mv nextflow /usr/local/bin/

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Provision Nextflow, nf-test and the Seqera CLI inside the dev container.
+set -euo pipefail
+
+echo "Installing Nextflow (NXF_VER=${NXF_VER:-latest})..."
+curl -s https://get.nextflow.io | bash
+sudo mv nextflow /usr/local/bin/
+nextflow -version
+
+echo "Installing nf-test..."
+curl -fsSL https://get.nf-test.com | bash
+sudo mv nf-test /usr/local/bin/
+nf-test version
+
+echo "Installing Seqera CLI..."
+npm install -g seqera
+seqera --version || true
+
+echo "Dev container setup complete."


### PR DESCRIPTION
## Summary

Adds a `.devcontainer/` spec so rnaseq-nf can be developed in VS Code / GitHub Codespaces with everything pre-installed.

- **Base:** `mcr.microsoft.com/devcontainers/base:ubuntu-24.04`
- **Features:**
  - `java:1` (v21, temurin) — matches CI, required by Nextflow & nf-test
  - `docker-in-docker:2` — so the pipeline can pull and run its process containers
  - `node:1` (lts) — for the Seqera CLI
- **`onCreateCommand` → `setup.sh`** installs:
  - Nextflow (`NXF_VER=25.10.4`, `NXF_SYNTAX_PARSER=v2`)
  - nf-test
  - Seqera CLI (`npm install -g seqera`)
- Adds the `nf-core.nf-core-extensionpack` VS Code extension.

Inspired by the [nextflow-io/training](https://github.com/nextflow-io/training) dev container. Simplified from that setup: training builds nf-test from source for v2-parser support, but the released `nf-test` (0.9.5) already handles the v2 parser, so a plain install suffices.

## Test plan

- [x] `devcontainer read-configuration` validates the config
- [ ] `devcontainer up` full build (image + features + setup.sh)
- [ ] Inside container: `nextflow -version`, `nf-test version`, `seqera --version`
- [ ] `nf-test test` and `nextflow run . -profile docker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)